### PR TITLE
fix: Bump provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.6.11"
     }
   }
 }


### PR DESCRIPTION
0.6.3 is not longer available. Would you mind to bump the versions in all of your modules?