### PR TITLE
Update provider dmacvicar/libvirt to 0.6.12

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.6.11"
+      version = "0.6.12"
     }
   }
 }


### PR DESCRIPTION
v0.6.12 was released 2021-12-12, see
* https://github.com/dmacvicar/terraform-provider-libvirt/releases/tag/v0.6.12 and
* https://registry.terraform.io/providers/dmacvicar/libvirt/latest